### PR TITLE
Added Sample Rate Divider config and Sensor Reset procedure.

### DIFF
--- a/drivers/sensor/tdk/mpu6050/Kconfig
+++ b/drivers/sensor/tdk/mpu6050/Kconfig
@@ -75,7 +75,9 @@ config MPU6050_SAMPLE_RATE_DIVIDER
 	help
 	  Sensor Data Sample Rate Divider.
 	  Sensor data Sample Rate = 8000Hz / (1 + Sample Rate Divider).
-	  While using I2C recommended Sensor Data Sample Rate is 1600Hz.
+	  While using I2C minimal Data Sample Rate Divider is 4, which results in 
+	  1600MHz Sensor Data Sample Rate. Sample Rates higher than this are not 
+	  recommended while using I2C.
 	  Valid values: X = [4, 255].
 
 endif # MPU6050

--- a/drivers/sensor/tdk/mpu6050/Kconfig
+++ b/drivers/sensor/tdk/mpu6050/Kconfig
@@ -76,7 +76,7 @@ config MPU6050_SAMPLE_RATE_DIVIDER
 	  Sensor Data Sample Rate Divider.
 	  Sensor data Sample Rate = 8000Hz / (1 + Sample Rate Divider).
 	  While using I2C minimal Data Sample Rate Divider is 4, which results in 
-	  1600MHz Sensor Data Sample Rate. Sample Rates higher than this are not 
+	  1600Hz Sensor Data Sample Rate. Sample Rates higher than this are not 
 	  recommended while using I2C.
 	  Valid values: X = [4, 255].
 

--- a/drivers/sensor/tdk/mpu6050/Kconfig
+++ b/drivers/sensor/tdk/mpu6050/Kconfig
@@ -69,4 +69,13 @@ config MPU6050_GYRO_FS
 	  An X value for the config represents a range of +/- X degrees/second.
 	  Valid values are 250, 500, 1000, 2000.
 
+config MPU6050_SAMPLE_RATE_DIVIDER
+	int "Data Sample Rate Divider"
+	default 7
+	help
+	  Sensor Data Sample Rate Divider.
+	  Sensor data Sample Rate = 8000Hz / (1 + Sample Rate Divider).
+	  While using I2C recommended Sensor Data Sample Rate is 1600Hz.
+	  Valid values: X = [4, 255].
+
 endif # MPU6050

--- a/drivers/sensor/tdk/mpu6050/Kconfig
+++ b/drivers/sensor/tdk/mpu6050/Kconfig
@@ -71,6 +71,7 @@ config MPU6050_GYRO_FS
 
 config MPU6050_SAMPLE_RATE_DIVIDER
 	int "Data Sample Rate Divider"
+	range 4 255
 	default 7
 	help
 	  Sensor Data Sample Rate Divider.

--- a/drivers/sensor/tdk/mpu6050/mpu6050.c
+++ b/drivers/sensor/tdk/mpu6050/mpu6050.c
@@ -18,309 +18,283 @@ LOG_MODULE_REGISTER(MPU6050, CONFIG_SENSOR_LOG_LEVEL);
 
 /* see "Accelerometer Measurements" section from register map description */
 static void mpu6050_convert_accel(struct sensor_value *val, int16_t raw_val,
-				  uint16_t sensitivity_shift)
+                                  uint16_t sensitivity_shift)
 {
-	int64_t conv_val;
+        int64_t conv_val;
 
-	conv_val = ((int64_t)raw_val * SENSOR_G) >> sensitivity_shift;
-	val->val1 = conv_val / 1000000;
-	val->val2 = conv_val % 1000000;
+        conv_val = ((int64_t)raw_val * SENSOR_G) >> sensitivity_shift;
+        val->val1 = conv_val / 1000000;
+        val->val2 = conv_val % 1000000;
 }
 
 /* see "Gyroscope Measurements" section from register map description */
 static void mpu6050_convert_gyro(struct sensor_value *val, int16_t raw_val,
-				 uint16_t sensitivity_x10)
+                                 uint16_t sensitivity_x10)
 {
-	int64_t conv_val;
+        int64_t conv_val;
 
-	conv_val = ((int64_t)raw_val * SENSOR_PI * 10) /
-		   (sensitivity_x10 * 180U);
-	val->val1 = conv_val / 1000000;
-	val->val2 = conv_val % 1000000;
+        conv_val = ((int64_t)raw_val * SENSOR_PI * 10) / (sensitivity_x10 * 180U);
+        val->val1 = conv_val / 1000000;
+        val->val2 = conv_val % 1000000;
 }
 
 /* see "Temperature Measurement" section from register map description */
 static inline void mpu6050_convert_temp(enum mpu6050_device_type device_type,
-					struct sensor_value *val,
-					int16_t raw_val)
+                                        struct sensor_value *val, int16_t raw_val)
 {
-	int64_t tmp_val = (int64_t)raw_val * 1000000;
+        int64_t tmp_val = (int64_t)raw_val * 1000000;
 
-	switch (device_type) {
-	case DEVICE_TYPE_MPU6500:
-		tmp_val = (tmp_val * 1000 / 333870) + 21000000;
-		break;
+        switch (device_type) {
+        case DEVICE_TYPE_MPU6500:
+                tmp_val = (tmp_val * 1000 / 333870) + 21000000;
+                break;
 
-	case DEVICE_TYPE_MPU6050:
-	default:
-		tmp_val = (tmp_val / 340) + 36000000;
-	};
+        case DEVICE_TYPE_MPU6050:
+        default:
+                tmp_val = (tmp_val / 340) + 36000000;
+        };
 
-	val->val1 = tmp_val / 1000000;
-	val->val2 = tmp_val % 1000000;
+        val->val1 = tmp_val / 1000000;
+        val->val2 = tmp_val % 1000000;
 }
 
-static int mpu6050_channel_get(const struct device *dev,
-			       enum sensor_channel chan,
-			       struct sensor_value *val)
+static int mpu6050_channel_get(const struct device *dev, enum sensor_channel chan,
+                               struct sensor_value *val)
 {
-	struct mpu6050_data *drv_data = dev->data;
+        struct mpu6050_data *drv_data = dev->data;
 
-	switch (chan) {
-	case SENSOR_CHAN_ACCEL_XYZ:
-		mpu6050_convert_accel(val, drv_data->accel_x,
-				      drv_data->accel_sensitivity_shift);
-		mpu6050_convert_accel(val + 1, drv_data->accel_y,
-				      drv_data->accel_sensitivity_shift);
-		mpu6050_convert_accel(val + 2, drv_data->accel_z,
-				      drv_data->accel_sensitivity_shift);
-		break;
-	case SENSOR_CHAN_ACCEL_X:
-		mpu6050_convert_accel(val, drv_data->accel_x,
-				      drv_data->accel_sensitivity_shift);
-		break;
-	case SENSOR_CHAN_ACCEL_Y:
-		mpu6050_convert_accel(val, drv_data->accel_y,
-				      drv_data->accel_sensitivity_shift);
-		break;
-	case SENSOR_CHAN_ACCEL_Z:
-		mpu6050_convert_accel(val, drv_data->accel_z,
-				      drv_data->accel_sensitivity_shift);
-		break;
-	case SENSOR_CHAN_GYRO_XYZ:
-		mpu6050_convert_gyro(val, drv_data->gyro_x,
-				     drv_data->gyro_sensitivity_x10);
-		mpu6050_convert_gyro(val + 1, drv_data->gyro_y,
-				     drv_data->gyro_sensitivity_x10);
-		mpu6050_convert_gyro(val + 2, drv_data->gyro_z,
-				     drv_data->gyro_sensitivity_x10);
-		break;
-	case SENSOR_CHAN_GYRO_X:
-		mpu6050_convert_gyro(val, drv_data->gyro_x,
-				     drv_data->gyro_sensitivity_x10);
-		break;
-	case SENSOR_CHAN_GYRO_Y:
-		mpu6050_convert_gyro(val, drv_data->gyro_y,
-				     drv_data->gyro_sensitivity_x10);
-		break;
-	case SENSOR_CHAN_GYRO_Z:
-		mpu6050_convert_gyro(val, drv_data->gyro_z,
-				     drv_data->gyro_sensitivity_x10);
-		break;
-	case SENSOR_CHAN_DIE_TEMP:
-		mpu6050_convert_temp(drv_data->device_type, val, drv_data->temp);
-		break;
-	default:
-		return -ENOTSUP;
-	}
+        switch (chan) {
+        case SENSOR_CHAN_ACCEL_XYZ:
+                mpu6050_convert_accel(val, drv_data->accel_x, drv_data->accel_sensitivity_shift);
+                mpu6050_convert_accel(val + 1, drv_data->accel_y,
+                                      drv_data->accel_sensitivity_shift);
+                mpu6050_convert_accel(val + 2, drv_data->accel_z,
+                                      drv_data->accel_sensitivity_shift);
+                break;
+        case SENSOR_CHAN_ACCEL_X:
+                mpu6050_convert_accel(val, drv_data->accel_x, drv_data->accel_sensitivity_shift);
+                break;
+        case SENSOR_CHAN_ACCEL_Y:
+                mpu6050_convert_accel(val, drv_data->accel_y, drv_data->accel_sensitivity_shift);
+                break;
+        case SENSOR_CHAN_ACCEL_Z:
+                mpu6050_convert_accel(val, drv_data->accel_z, drv_data->accel_sensitivity_shift);
+                break;
+        case SENSOR_CHAN_GYRO_XYZ:
+                mpu6050_convert_gyro(val, drv_data->gyro_x, drv_data->gyro_sensitivity_x10);
+                mpu6050_convert_gyro(val + 1, drv_data->gyro_y, drv_data->gyro_sensitivity_x10);
+                mpu6050_convert_gyro(val + 2, drv_data->gyro_z, drv_data->gyro_sensitivity_x10);
+                break;
+        case SENSOR_CHAN_GYRO_X:
+                mpu6050_convert_gyro(val, drv_data->gyro_x, drv_data->gyro_sensitivity_x10);
+                break;
+        case SENSOR_CHAN_GYRO_Y:
+                mpu6050_convert_gyro(val, drv_data->gyro_y, drv_data->gyro_sensitivity_x10);
+                break;
+        case SENSOR_CHAN_GYRO_Z:
+                mpu6050_convert_gyro(val, drv_data->gyro_z, drv_data->gyro_sensitivity_x10);
+                break;
+        case SENSOR_CHAN_DIE_TEMP:
+                mpu6050_convert_temp(drv_data->device_type, val, drv_data->temp);
+                break;
+        default:
+                return -ENOTSUP;
+        }
 
-	return 0;
+        return 0;
 }
 
-static int mpu6050_sample_fetch(const struct device *dev,
-				enum sensor_channel chan)
+static int mpu6050_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
-	struct mpu6050_data *drv_data = dev->data;
-	const struct mpu6050_config *cfg = dev->config;
-	int16_t buf[7];
+        struct mpu6050_data *drv_data = dev->data;
+        const struct mpu6050_config *cfg = dev->config;
+        int16_t buf[7];
 
-	if (i2c_burst_read_dt(&cfg->i2c, MPU6050_REG_DATA_START, (uint8_t *)buf,
-			      14) < 0) {
-		LOG_ERR("Failed to read data sample.");
-		return -EIO;
-	}
+        if (i2c_burst_read_dt(&cfg->i2c, MPU6050_REG_DATA_START, (uint8_t *)buf, 14) < 0) {
+                LOG_ERR("Failed to read data sample.");
+                return -EIO;
+        }
 
-	drv_data->accel_x = sys_be16_to_cpu(buf[0]);
-	drv_data->accel_y = sys_be16_to_cpu(buf[1]);
-	drv_data->accel_z = sys_be16_to_cpu(buf[2]);
-	drv_data->temp = sys_be16_to_cpu(buf[3]);
-	drv_data->gyro_x = sys_be16_to_cpu(buf[4]);
-	drv_data->gyro_y = sys_be16_to_cpu(buf[5]);
-	drv_data->gyro_z = sys_be16_to_cpu(buf[6]);
+        drv_data->accel_x = sys_be16_to_cpu(buf[0]);
+        drv_data->accel_y = sys_be16_to_cpu(buf[1]);
+        drv_data->accel_z = sys_be16_to_cpu(buf[2]);
+        drv_data->temp = sys_be16_to_cpu(buf[3]);
+        drv_data->gyro_x = sys_be16_to_cpu(buf[4]);
+        drv_data->gyro_y = sys_be16_to_cpu(buf[5]);
+        drv_data->gyro_z = sys_be16_to_cpu(buf[6]);
 
-	return 0;
+        return 0;
 }
 
 static const struct sensor_driver_api mpu6050_driver_api = {
 #if CONFIG_MPU6050_TRIGGER
-	.trigger_set = mpu6050_trigger_set,
+        .trigger_set = mpu6050_trigger_set,
 #endif
-	.sample_fetch = mpu6050_sample_fetch,
-	.channel_get = mpu6050_channel_get,
+        .sample_fetch = mpu6050_sample_fetch,
+        .channel_get = mpu6050_channel_get,
 };
 
 int mpu6050_init(const struct device *dev)
 {
-	struct mpu6050_data *drv_data = dev->data;
-	const struct mpu6050_config *cfg = dev->config;
-	uint8_t id, i;
+        struct mpu6050_data *drv_data = dev->data;
+        const struct mpu6050_config *cfg = dev->config;
+        uint8_t id, i;
 
-	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
-		return -ENODEV;
-	}
+        if (!device_is_ready(cfg->i2c.bus)) {
+                LOG_ERR("Bus device is not ready");
+                return -ENODEV;
+        }
 
-	/* check chip ID */
-	if (i2c_reg_read_byte_dt(&cfg->i2c, MPU6050_REG_CHIP_ID, &id) < 0) {
-		LOG_ERR("Failed to read chip ID.");
-		return -EIO;
-	}
+        /* check chip ID */
+        if (i2c_reg_read_byte_dt(&cfg->i2c, MPU6050_REG_CHIP_ID, &id) < 0) {
+                LOG_ERR("Failed to read chip ID.");
+                return -EIO;
+        }
 
-	if (id == MPU6050_CHIP_ID || id == MPU9250_CHIP_ID || id == MPU6880_CHIP_ID) {
-		LOG_DBG("MPU6050/MPU9250/MPU6880 detected");
-		drv_data->device_type = DEVICE_TYPE_MPU6050;
-	} else if (id == MPU6500_CHIP_ID) {
-		LOG_DBG("MPU6500 detected");
-		drv_data->device_type = DEVICE_TYPE_MPU6500;
-	} else {
-		LOG_ERR("Invalid chip ID.");
-		return -EINVAL;
-	}
+        if (id == MPU6050_CHIP_ID || id == MPU9250_CHIP_ID || id == MPU6880_CHIP_ID) {
+                LOG_DBG("MPU6050/MPU9250/MPU6880 detected");
+                drv_data->device_type = DEVICE_TYPE_MPU6050;
+        } else if (id == MPU6500_CHIP_ID) {
+                LOG_DBG("MPU6500 detected");
+                drv_data->device_type = DEVICE_TYPE_MPU6500;
+        } else {
+                LOG_ERR("Invalid chip ID.");
+                return -EINVAL;
+        }
 
-	/* Reset sequence is added to ensure all registers are reset to their 
-	 * default values, and also to enable easier addition of SPI support in 
-	 * future. 
-	 */
-	/* When using SPI interface, user should use DEVICE_RESET as well as
-	 * SIGNAL_PATH_RESET to ensure th ereest is performed properly.
-	 * The sequence used should be:
-	 * 1. Set DEVICE_RESET = 1 (reg PWR_MGMT_1)
-	 * 2. Wait 100ms
-	 * 3. Set GYRO_RESET = ACCEL_RESET = TEMP_RESET = 1 (reg SIGNAL_PATH_RESET)
-	 * 4. Wait 100ms 
-	 * (RM-MPU-6000A-00 rev 4.2 page 41 of 46) */
-	if (i2c_reg_write_byte_dt(&cfg->i2c, MPU6050_REG_PWR_MGMT1, 
-							MPU6050_DEVICE_RESET) < 0) {
-		LOG_ERR("Device reset failed.");
-		return -EIO;
-	}
+        /* Reset sequence is added to ensure all registers are reset to their
+         * default values, and also to enable easier addition of SPI support in
+         * future.
+         */
+        /* When using SPI interface, user should use DEVICE_RESET as well as
+         * SIGNAL_PATH_RESET to ensure th ereest is performed properly.
+         * The sequence used should be:
+         * 1. Set DEVICE_RESET = 1 (reg PWR_MGMT_1)
+         * 2. Wait 100ms
+         * 3. Set GYRO_RESET = ACCEL_RESET = TEMP_RESET = 1 (reg SIGNAL_PATH_RESET)
+         * 4. Wait 100ms
+         * (RM-MPU-6000A-00 rev 4.2 page 41 of 46) */
+        if (i2c_reg_write_byte_dt(&cfg->i2c, MPU6050_REG_PWR_MGMT1, MPU6050_DEVICE_RESET) < 0) {
+                LOG_ERR("Device reset failed.");
+                return -EIO;
+        }
 
-	k_sleep(K_MSEC(100));
-	
-	// check content of Power Management 1 register.
-	uint8_t tmp;
-	if ((i2c_reg_read_byte_dt(&cfg->i2c, MPU6050_REG_PWR_MGMT1, &tmp) < 0)) {
-		LOG_ERR("Device reset request failed.");
-		return -EIO;
-	}
+        k_sleep(K_MSEC(100));
 
-	if (tmp != MPU6050_PWR_MGMT1_RST_VAL) {
-		LOG_ERR("Device reset failed.");
-		return -EINVAL;
-	}
+        /* check content of Power Management 1 register. */
+        uint8_t tmp;
+        if ((i2c_reg_read_byte_dt(&cfg->i2c, MPU6050_REG_PWR_MGMT1, &tmp) < 0)) {
+                LOG_ERR("Device reset request failed.");
+                return -EIO;
+        }
 
-	// select clock source.
-	/* While gyros are active, selecting the gyros as the clock source provides 
-	 * for a more accurate clock source. 
-	 * (Document Number: PS-MPU-6000A-00 Page 30 of 52) */
-	if (i2c_reg_write_byte_dt(&cfg->i2c, MPU6050_REG_PWR_MGMT1, 0x01) < 0) {
-		LOG_ERR("Clock select failed.");
-		return -EIO;
-	}
+        if (tmp != MPU6050_PWR_MGMT1_RST_VAL) {
+                LOG_ERR("Device reset failed.");
+                return -EINVAL;
+        }
 
-	// signal paths reset.
-	if (i2c_reg_update_byte_dt(&cfg->i2c, MPU6050_REG_SIGNAL_PATH_RESET, 
-			(MPU6050_GYRO_RESET | MPU6050_ACCEL_RESET | MPU6050_TEMP_RESET), 
-			0b00000111) < 0) {
-		LOG_ERR("Signal path reset failed.");
-		return -EIO;
-	}
+        /* select clock source.
+         * While gyros are active, selecting the gyros as the clock source provides
+         * for a more accurate clock source.
+         * (Document Number: PS-MPU-6000A-00 Page 30 of 52) */
+        if (i2c_reg_write_byte_dt(&cfg->i2c, MPU6050_REG_PWR_MGMT1, 0x01) < 0) {
+                LOG_ERR("Clock select failed.");
+                return -EIO;
+        }
 
-	// reset signal paths of all sensors and clear sensor registers.
-	if (i2c_reg_update_byte_dt(&cfg->i2c, MPU6050_REG_USER_CTRL, 
-						MPU6050_SIG_COND_RESET, 1) < 0) {
-		LOG_ERR("Signal path reset failed.");
-		return -EIO;
-	}
+        /* signal paths reset. */
+        if (i2c_reg_update_byte_dt(&cfg->i2c, MPU6050_REG_SIGNAL_PATH_RESET,
+                        (MPU6050_GYRO_RESET | MPU6050_ACCEL_RESET | MPU6050_TEMP_RESET),
+                        0b00000111) < 0) {
+                LOG_ERR("Signal path reset failed.");
+                return -EIO;
+        }
 
-	k_sleep(K_MSEC(100));
+        /* reset signal paths of all sensors and clear sensor registers. */
+        if (i2c_reg_update_byte_dt(&cfg->i2c, MPU6050_REG_USER_CTRL,
+                                                MPU6050_SIG_COND_RESET, 1) < 0) {
+                LOG_ERR("Signal path reset failed.");
+                return -EIO;
+        }
 
-	// Configure Sample Rate Divider.
-	if ((CONFIG_MPU6050_SAMPLE_RATE_DIVIDER > MPU6050_SMPRT_DIV_MAX)
-		|| (CONFIG_MPU6050_SAMPLE_RATE_DIVIDER < MPU6050_SMPRT_DIV_MIN)) {
-		LOG_ERR("Invalid sample rate divider.");
-		return -EINVAL;
-	}
+        k_sleep(K_MSEC(100));
 
-	/* Sample Rate = Gyroscope Output Rate / (1 + smplrt_div)
-	 * (RM-MPU-6000A-00 rev 4.2 page 12 of 46) */
-	if (i2c_reg_write_byte_dt(&cfg->i2c, MPU6050_REG_SAMPLE_RATE_DIVIDER, 
-						CONFIG_MPU6050_SAMPLE_RATE_DIVIDER) < 0) {
-		LOG_ERR("Sample rate divider configuration failed.");
-		return -EIO;
-	}
+        /* Sample Rate = Gyroscope Output Rate / (1 + smplrt_div)
+         * (RM-MPU-6000A-00 rev 4.2 page 12 of 46) */
+        if (i2c_reg_write_byte_dt(&cfg->i2c, MPU6050_REG_SAMPLE_RATE_DIVIDER,
+                                  CONFIG_MPU6050_SAMPLE_RATE_DIVIDER) < 0) {
+                LOG_ERR("Sample rate divider configuration failed.");
+                return -EIO;
+        }
 
-	/* set accelerometer full-scale range */
-	for (i = 0U; i < 4; i++) {
-		if (BIT(i+1) == CONFIG_MPU6050_ACCEL_FS) {
-			break;
-		}
-	}
+        /* set accelerometer full-scale range */
+        for (i = 0U; i < 4; i++) {
+                if (BIT(i + 1) == CONFIG_MPU6050_ACCEL_FS) {
+                        break;
+                }
+        }
 
-	if (i == 4U) {
-		LOG_ERR("Invalid value for accel full-scale range.");
-		return -EINVAL;
-	}
+        if (i == 4U) {
+                LOG_ERR("Invalid value for accel full-scale range.");
+                return -EINVAL;
+        }
 
-	if (i2c_reg_write_byte_dt(&cfg->i2c, MPU6050_REG_ACCEL_CFG,
-				  i << MPU6050_ACCEL_FS_SHIFT) < 0) {
-		LOG_ERR("Failed to write accel full-scale range.");
-		return -EIO;
-	}
+        if (i2c_reg_write_byte_dt(&cfg->i2c, MPU6050_REG_ACCEL_CFG, i << MPU6050_ACCEL_FS_SHIFT) <
+            0) {
+                LOG_ERR("Failed to write accel full-scale range.");
+                return -EIO;
+        }
 
-	drv_data->accel_sensitivity_shift = 14 - i;
+        drv_data->accel_sensitivity_shift = 14 - i;
 
-	/* set gyroscope full-scale range */
-	for (i = 0U; i < 4; i++) {
-		if (BIT(i) * 250 == CONFIG_MPU6050_GYRO_FS) {
-			break;
-		}
-	}
+        /* set gyroscope full-scale range */
+        for (i = 0U; i < 4; i++) {
+                if (BIT(i) * 250 == CONFIG_MPU6050_GYRO_FS) {
+                        break;
+                }
+        }
 
-	if (i == 4U) {
-		LOG_ERR("Invalid value for gyro full-scale range.");
-		return -EINVAL;
-	}
+        if (i == 4U) {
+                LOG_ERR("Invalid value for gyro full-scale range.");
+                return -EINVAL;
+        }
 
-	if (i2c_reg_write_byte_dt(&cfg->i2c, MPU6050_REG_GYRO_CFG,
-				  i << MPU6050_GYRO_FS_SHIFT) < 0) {
-		LOG_ERR("Failed to write gyro full-scale range.");
-		return -EIO;
-	}
+        if (i2c_reg_write_byte_dt(&cfg->i2c, MPU6050_REG_GYRO_CFG, i << MPU6050_GYRO_FS_SHIFT) <
+            0) {
+                LOG_ERR("Failed to write gyro full-scale range.");
+                return -EIO;
+        }
 
-	drv_data->gyro_sensitivity_x10 = mpu6050_gyro_sensitivity_x10[i];
+        drv_data->gyro_sensitivity_x10 = mpu6050_gyro_sensitivity_x10[i];
 
 #ifdef CONFIG_MPU6050_TRIGGER
-	if (cfg->int_gpio.port) {
-		if (mpu6050_init_interrupt(dev) < 0) {
-			LOG_DBG("Failed to initialize interrupts.");
-			return -EIO;
-		}
-	}
+        if (cfg->int_gpio.port) {
+                if (mpu6050_init_interrupt(dev) < 0) {
+                        LOG_DBG("Failed to initialize interrupts.");
+                        return -EIO;
+                }
+        }
 #endif
 
-	// wake up chip
-	if (i2c_reg_update_byte_dt(&cfg->i2c, MPU6050_REG_PWR_MGMT1,
-                            MPU6050_SLEEP_EN, 0) < 0) {
-		LOG_ERR("Failed to wake up chip.");
-		return -EIO;
-	}
+        /* wake up chip */
+        if (i2c_reg_update_byte_dt(&cfg->i2c, MPU6050_REG_PWR_MGMT1, MPU6050_SLEEP_EN, 0) < 0) {
+                LOG_ERR("Failed to wake up chip.");
+                return -EIO;
+        }
 
-	return 0;
+        return 0;
 }
 
-#define MPU6050_DEFINE(inst)									\
-	static struct mpu6050_data mpu6050_data_##inst;						\
-												\
-	static const struct mpu6050_config mpu6050_config_##inst = {				\
-		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
-		IF_ENABLED(CONFIG_MPU6050_TRIGGER,						\
-			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
-	};											\
-												\
-	SENSOR_DEVICE_DT_INST_DEFINE(inst, mpu6050_init, NULL,					\
-			      &mpu6050_data_##inst, &mpu6050_config_##inst,			\
-			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
-			      &mpu6050_driver_api);						\
+#define MPU6050_DEFINE(inst)                                                                       \
+        static struct mpu6050_data mpu6050_data_##inst;                                            \
+                                                                                                   \
+        static const struct mpu6050_config mpu6050_config_##inst = {                               \
+                .i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
+                IF_ENABLED(CONFIG_MPU6050_TRIGGER,                                              \
+                           (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),)) };     \
+                                                                                                   \
+        SENSOR_DEVICE_DT_INST_DEFINE(inst, mpu6050_init, NULL, &mpu6050_data_##inst,               \
+                                     &mpu6050_config_##inst, POST_KERNEL,                          \
+                                     CONFIG_SENSOR_INIT_PRIORITY, &mpu6050_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MPU6050_DEFINE)

--- a/drivers/sensor/tdk/mpu6050/mpu6050.h
+++ b/drivers/sensor/tdk/mpu6050/mpu6050.h
@@ -14,25 +14,50 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
+// Chip ID Register
 #define MPU6050_REG_CHIP_ID		0x75
 #define MPU6050_CHIP_ID			0x68
 #define MPU6500_CHIP_ID			0x70
 #define MPU9250_CHIP_ID			0x71
 #define MPU6880_CHIP_ID			0x19
 
+// Sample Rate Divider Register
+#define MPU6050_REG_SAMPLE_RATE_DIVIDER	0x19
+
+// Gyro Config Register
 #define MPU6050_REG_GYRO_CFG		0x1B
 #define MPU6050_GYRO_FS_SHIFT		3
 
+// Accel Config Register
 #define MPU6050_REG_ACCEL_CFG		0x1C
 #define MPU6050_ACCEL_FS_SHIFT		3
 
+// Interrupt Enable Register
 #define MPU6050_REG_INT_EN		0x38
 #define MPU6050_DRDY_EN			BIT(0)
 
+// Sensor Data Start
 #define MPU6050_REG_DATA_START		0x3B
 
+// Signal Path Reset Register
+#define MPU6050_REG_SIGNAL_PATH_RESET	0x68
+#define MPU6050_TEMP_RESET				BIT(0)
+#define MPU6050_ACCEL_RESET				BIT(1)
+#define MPU6050_GYRO_RESET				BIT(2)
+
+// User Control Register
+#define MPU6050_REG_USER_CTRL			0x6A
+#define MPU6050_SIG_COND_RESET			BIT(0)
+
+// Power Management 1 Register
 #define MPU6050_REG_PWR_MGMT1		0x6B
-#define MPU6050_SLEEP_EN		BIT(6)
+#define MPU6050_SLEEP_EN			BIT(6)
+#define MPU6050_DEVICE_RESET		BIT(7)
+#define MPU6050_PWR_MGMT1_RST_VAL	0x40
+
+// Sample Rate Divider limits
+#define MPU6050_SMPRT_DIV_MIN	4
+#define MPU6050_SMPRT_DIV_MAX 	255
 
 /* measured in degrees/sec x10 to avoid floating point */
 static const uint16_t mpu6050_gyro_sensitivity_x10[] = {

--- a/drivers/sensor/tdk/mpu6050/mpu6050.h
+++ b/drivers/sensor/tdk/mpu6050/mpu6050.h
@@ -14,106 +14,99 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
-// Chip ID Register
-#define MPU6050_REG_CHIP_ID		0x75
-#define MPU6050_CHIP_ID			0x68
-#define MPU6500_CHIP_ID			0x70
-#define MPU9250_CHIP_ID			0x71
-#define MPU6880_CHIP_ID			0x19
+/* Chip ID Register */
+#define MPU6050_REG_CHIP_ID 0x75
+#define MPU6050_CHIP_ID     0x68
+#define MPU6500_CHIP_ID     0x70
+#define MPU9250_CHIP_ID     0x71
+#define MPU6880_CHIP_ID     0x19
 
-// Sample Rate Divider Register
-#define MPU6050_REG_SAMPLE_RATE_DIVIDER	0x19
+/* Sample Rate Divider Register */
+#define MPU6050_REG_SAMPLE_RATE_DIVIDER 0x19
 
-// Gyro Config Register
-#define MPU6050_REG_GYRO_CFG		0x1B
-#define MPU6050_GYRO_FS_SHIFT		3
+/* Gyro Config Register */
+#define MPU6050_REG_GYRO_CFG  0x1B
+#define MPU6050_GYRO_FS_SHIFT 3
 
-// Accel Config Register
-#define MPU6050_REG_ACCEL_CFG		0x1C
-#define MPU6050_ACCEL_FS_SHIFT		3
+/* Accel Config Register */
+#define MPU6050_REG_ACCEL_CFG  0x1C
+#define MPU6050_ACCEL_FS_SHIFT 3
 
-// Interrupt Enable Register
-#define MPU6050_REG_INT_EN		0x38
-#define MPU6050_DRDY_EN			BIT(0)
+/* Interrupt Enable Register */
+#define MPU6050_REG_INT_EN 0x38
+#define MPU6050_DRDY_EN    BIT(0)
 
-// Sensor Data Start
-#define MPU6050_REG_DATA_START		0x3B
+/* Sensor Data Start */
+#define MPU6050_REG_DATA_START 0x3B
 
-// Signal Path Reset Register
-#define MPU6050_REG_SIGNAL_PATH_RESET	0x68
-#define MPU6050_TEMP_RESET				BIT(0)
-#define MPU6050_ACCEL_RESET				BIT(1)
-#define MPU6050_GYRO_RESET				BIT(2)
+/* Signal Path Reset Register */
+#define MPU6050_REG_SIGNAL_PATH_RESET 0x68
+#define MPU6050_TEMP_RESET            BIT(0)
+#define MPU6050_ACCEL_RESET           BIT(1)
+#define MPU6050_GYRO_RESET            BIT(2)
 
-// User Control Register
-#define MPU6050_REG_USER_CTRL			0x6A
-#define MPU6050_SIG_COND_RESET			BIT(0)
+/* User Control Register */
+#define MPU6050_REG_USER_CTRL  0x6A
+#define MPU6050_SIG_COND_RESET BIT(0)
 
-// Power Management 1 Register
-#define MPU6050_REG_PWR_MGMT1		0x6B
-#define MPU6050_SLEEP_EN			BIT(6)
-#define MPU6050_DEVICE_RESET		BIT(7)
-#define MPU6050_PWR_MGMT1_RST_VAL	0x40
-
-// Sample Rate Divider limits
-#define MPU6050_SMPRT_DIV_MIN	4
-#define MPU6050_SMPRT_DIV_MAX 	255
+/* Power Management 1 Register */
+#define MPU6050_REG_PWR_MGMT1     0x6B
+#define MPU6050_SLEEP_EN          BIT(6)
+#define MPU6050_DEVICE_RESET      BIT(7)
+#define MPU6050_PWR_MGMT1_RST_VAL 0x40
 
 /* measured in degrees/sec x10 to avoid floating point */
-static const uint16_t mpu6050_gyro_sensitivity_x10[] = {
-	1310, 655, 328, 164
-};
+static const uint16_t mpu6050_gyro_sensitivity_x10[] = {1310, 655, 328, 164};
 
 /* Device type, uses the correct offets for a particular device */
 enum mpu6050_device_type {
-	DEVICE_TYPE_MPU6050 = 0,
-	DEVICE_TYPE_MPU6500,
+        DEVICE_TYPE_MPU6050 = 0,
+        DEVICE_TYPE_MPU6500,
 };
 
 struct mpu6050_data {
-	int16_t accel_x;
-	int16_t accel_y;
-	int16_t accel_z;
-	uint16_t accel_sensitivity_shift;
+        int16_t accel_x;
+        int16_t accel_y;
+        int16_t accel_z;
+        uint16_t accel_sensitivity_shift;
 
-	int16_t temp;
+        int16_t temp;
 
-	int16_t gyro_x;
-	int16_t gyro_y;
-	int16_t gyro_z;
-	uint16_t gyro_sensitivity_x10;
+        int16_t gyro_x;
+        int16_t gyro_y;
+        int16_t gyro_z;
+        uint16_t gyro_sensitivity_x10;
 
-	enum mpu6050_device_type device_type;
+        enum mpu6050_device_type device_type;
 
 #ifdef CONFIG_MPU6050_TRIGGER
-	const struct device *dev;
-	struct gpio_callback gpio_cb;
+        const struct device *dev;
+        struct gpio_callback gpio_cb;
 
-	const struct sensor_trigger *data_ready_trigger;
-	sensor_trigger_handler_t data_ready_handler;
+        const struct sensor_trigger *data_ready_trigger;
+        sensor_trigger_handler_t data_ready_handler;
 
 #if defined(CONFIG_MPU6050_TRIGGER_OWN_THREAD)
-	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_MPU6050_THREAD_STACK_SIZE);
-	struct k_thread thread;
-	struct k_sem gpio_sem;
+        K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_MPU6050_THREAD_STACK_SIZE);
+        struct k_thread thread;
+        struct k_sem gpio_sem;
 #elif defined(CONFIG_MPU6050_TRIGGER_GLOBAL_THREAD)
-	struct k_work work;
+        struct k_work work;
 #endif
 
 #endif /* CONFIG_MPU6050_TRIGGER */
 };
 
 struct mpu6050_config {
-	struct i2c_dt_spec i2c;
+        struct i2c_dt_spec i2c;
 #ifdef CONFIG_MPU6050_TRIGGER
-	struct gpio_dt_spec int_gpio;
+        struct gpio_dt_spec int_gpio;
 #endif /* CONFIG_MPU6050_TRIGGER */
 };
 
 #ifdef CONFIG_MPU6050_TRIGGER
-int mpu6050_trigger_set(const struct device *dev,
-			const struct sensor_trigger *trig,
-			sensor_trigger_handler_t handler);
+int mpu6050_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+                        sensor_trigger_handler_t handler);
 
 int mpu6050_init_interrupt(const struct device *dev);
 #endif


### PR DESCRIPTION
Added support for configuration of Sample Rate Divider, needed to downrate sensor data output from default 8KHz to a value which can be supported by I2C.

Added Sensor Reset procedure which is required by manufacturer for SPI usage.